### PR TITLE
fix: restore CI compatibility after dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.100.0
+      - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
         with:
           key: msrv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,17 +973,14 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1257,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1700,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,14 +973,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1254,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1697,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ filetime = "0.2"
 fs2 = "0.4"
 gethostname = "1.1"
 rayon = "1.11"
-rusqlite = { version = "0.40", features = ["backup", "bundled"] }
+rusqlite = { version = "0.39", features = ["backup", "bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sysinfo = { version = "0.36.1", default-features = false, features = ["system"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ filetime = "0.2"
 fs2 = "0.4"
 gethostname = "1.1"
 rayon = "1.11"
-rusqlite = { version = "0.39", features = ["backup", "bundled"] }
+rusqlite = { version = "0.40.2", features = ["backup", "bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sysinfo = { version = "0.36.1", default-features = false, features = ["system"] }

--- a/src/source.rs
+++ b/src/source.rs
@@ -1180,7 +1180,7 @@ fn assemble_session_rows(
         rows.truncate(SESSION_ROWS_CAP);
     }
     // Stable presentation: most recent first within the capped set.
-    rows.sort_by(|a, b| b.last_seen_ms.cmp(&a.last_seen_ms));
+    rows.sort_by_key(|row| std::cmp::Reverse(row.last_seen_ms));
 
     let included = rows.len() as u64;
     SessionRowsSummary {


### PR DESCRIPTION
## Summary

- restore the documented Rust 1.85 CI toolchain after the invalid 1.100 action update
- update rusqlite from 0.40.1 to patched 0.40.2, whose libsqlite3-sys 0.38.2 build script is compatible with Rust 1.85
- use key-based reverse sorting to satisfy current stable Clippy without changing row order

This repairs the base-branch failures currently inherited by #9 and #10. The patched SQLite stack retains the 0.40 savepoint hardening and bundled SQLite line while restoring the repository's declared MSRV.

## Validation

- `cargo +1.85.0 check --all-targets --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-targets --locked` (71 tests)
- `AKEEP_BIN=target/debug/akeep ./scripts/demo.sh`
- `cargo package --locked --allow-dirty`

## Impact

No archive format, recovery behavior, privacy boundary, CLI output, public API, or release behavior changes.